### PR TITLE
Fix invalid prefcolor

### DIFF
--- a/spingen-lib/src/lib.rs
+++ b/spingen-lib/src/lib.rs
@@ -272,23 +272,21 @@ impl Spingen {
         };
 
         // get spray if it exists
-        let Some(spray) = spray_id
-            .as_ref()
-            .and_then(|spray_id| self.sprays.get(spray_id))
-            .or_else(|| {
-                self.sprays
-                    .values()
-                    .find(|spray| spray.name.eq_ignore_ascii_case(&skin.prefcolor))
-            })
-        else {
-            if let Some(spray) = spray_id {
-                return Err(format!("spray \"{}\" not found", spray).into());
+        let spray = if let Some(spray_id) = spray_id {
+            match self.sprays.get(&spray_id) {
+                Some(spray) => spray,
+                None => return Err(format!("spray \"{}\" not found", spray_id).into()),
+            }
+        } else {
+            let spray = self
+                .sprays
+                .values()
+                .find(|spray| spray.name.eq_ignore_ascii_case(&skin.prefcolor));
+            if let Some(spray) = spray {
+                spray
             } else {
-                return Err(format!(
-                    "skin \"{}\" has invalid prefcolor \"{}\"",
-                    skin.name, skin.prefcolor
-                )
-                .into());
+                warn!("invalid prefcolor {:?}, using default", skin.prefcolor);
+                self.sprays.values().next().expect("at least 1 spray")
             }
         };
 

--- a/spingen-lib/src/spray/loaders/pk3.rs
+++ b/spingen-lib/src/spray/loaders/pk3.rs
@@ -138,7 +138,13 @@ impl Pk3SprayLoader {
                     name,
                     value: Some(value),
                 } if name.eq_ignore_ascii_case("SKINCOLOR") && is_skincolor_name(value) => {
-                    let spray = self.sprays.entry(value.to_owned()).or_default();
+                    let spray = self
+                        .sprays
+                        .entry(value.to_owned())
+                        .or_insert_with_key(|key| DoomSpray {
+                            id: key.clone(),
+                            ..Default::default()
+                        });
                     /*
                     let Some(spray) = self.sprays.get_mut(value) else {
                         return Err(Report::msg(format!("undefined skincolor: \"{}\"", value)))

--- a/spingen-lib/src/spray/loaders/pk3.rs
+++ b/spingen-lib/src/spray/loaders/pk3.rs
@@ -138,10 +138,12 @@ impl Pk3SprayLoader {
                     name,
                     value: Some(value),
                 } if name.eq_ignore_ascii_case("SKINCOLOR") && is_skincolor_name(value) => {
+                    let spray = self.sprays.entry(value.to_owned()).or_default();
+                    /*
                     let Some(spray) = self.sprays.get_mut(value) else {
                         return Err(Report::msg(format!("undefined skincolor: \"{}\"", value)))
                             .wrap_err_with(wrap_err);
-                    };
+                    };*/
 
                     let deser_spray = parser
                         .deserialize::<OptionalSpray>()


### PR DESCRIPTION
Fixes a bug that causes invalid or undiscovered prefcolors from destroying kart buttons. Also fixes an SOC oversight to fix most invalid prefcolor errors better.